### PR TITLE
Fix a no postcard error for my trips page

### DIFF
--- a/frontend/src/components/maps/trips_index/trips_index_map.jsx
+++ b/frontend/src/components/maps/trips_index/trips_index_map.jsx
@@ -15,7 +15,9 @@ class TripsIndexMap extends React.Component {
     this.trips = [];
     this.tripsWithPos = attachAllTripPos(props.trips, props.postcards);
     
-    const { lat, lng } = averagePos(this.tripsWithPos);
+    let { lat, lng } = averagePos(this.tripsWithPos);
+    if (!lat || !lng) [lat, lng] = [40.711457884430985, -74.00372005691278];
+    
     this.center = { lat, lng };
     this.zoom = 0;
   }


### PR DESCRIPTION
Added a catch just in case a user doesn't have any postcards or trips.